### PR TITLE
Psilord/feature/orient fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ of writing, this currently includes: ABCL, SBCL, CCL, ECL, and Clasp.
 (ql:quickload :origin)
 ```
 
+## Contributors
+
+* [Peter Keller](https://github.com/psilord) - Special thanks for contributions
+  and correctness checking.
+
 ## License
 
 Copyright © 2014-2018 [Michael Fiano](mailto:mail@michaelfiano.com).

--- a/origin.asd
+++ b/origin.asd
@@ -1,5 +1,5 @@
 (asdf:defsystem #:origin
-  :description ""
+  :description "A native Lisp graphics math library with an emphasis on performance and correctness."
   :author "Michael Fiano <mail@michaelfiano.com>"
   :maintainer "Michael Fiano <mail@michaelfiano.com>"
   :license "MIT"

--- a/src/quat.lisp
+++ b/src/quat.lisp
@@ -535,7 +535,7 @@
   (from-axis-angle! (id) axis angle))
 
 (define-op orient! ((out quat) (space keyword)
-                    &rest (axes/angles (or keyword v3:vec)))
+                    &rest (axes/angles (or keyword v3:vec real)))
     (:out quat)
   (with-components ((o out))
     (with-elements ((q 1f0 0f0 0f0 0f0))
@@ -557,6 +557,6 @@
                   (normalize! out out)))))
   out)
 
-(define-op orient ((space keyword) &rest (axes/angles (or keyword v3:vec)))
+(define-op orient ((space keyword) &rest (axes/angles (or keyword v3:vec real)))
     (:out quat)
   (apply #'orient! (id) space axes/angles))


### PR DESCRIPTION
Orient's rest arguments need to be keywords, vec3s, and reals.