### PR TITLE
Psilord/feature/rotate name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ of writing, this currently includes: ABCL, SBCL, CCL, ECL, and Clasp.
 (ql:quickload :origin)
 ```
 
+## Contributors
+
+* [Peter Keller](https://github.com/psilord) - Special thanks for contributions
+  and correctness checking.
+
 ## License
 
 Copyright © 2014-2018 [Michael Fiano](mailto:mail@michaelfiano.com).

--- a/origin.asd
+++ b/origin.asd
@@ -1,5 +1,5 @@
 (asdf:defsystem #:origin
-  :description ""
+  :description "A native Lisp graphics math library with an emphasis on performance and correctness."
   :author "Michael Fiano <mail@michaelfiano.com>"
   :maintainer "Michael Fiano <mail@michaelfiano.com>"
   :license "MIT"

--- a/src/quat.lisp
+++ b/src/quat.lisp
@@ -316,19 +316,19 @@
     (:out quat)
   (rotate-euler! (id) in vec :space space))
 
-(define-op rotate! ((out quat) (in quat) (rot quat)
+(define-op rotate! ((out quat) (in1 quat) (in2 quat)
                     &key (space keyword :local))
     (:out quat :inline nil)
   (ecase space
     (:local
-      (*! out in rot))
+      (*! out in1 in2))
     (:world
-     (*! out rot in)))
+     (*! out in2 in1)))
   (normalize! out out))
 
-(define-op rotate ((in quat) (rot quat) &key (space keyword :local))
+(define-op rotate ((in1 quat) (in2 quat) &key (space keyword :local))
     (:out quat)
-  (rotate! (id) in rot :space space))
+  (rotate! (id) in1 in2 :space space))
 
 (define-op to-vec3! ((out v3:vec) (in quat)) (:out v3:vec)
   (v3:with-components ((v out))

--- a/src/quat.lisp
+++ b/src/quat.lisp
@@ -56,6 +56,8 @@
    #:dot
    #:inverse!
    #:inverse
+   #:rotate-euler!
+   #:rotate-euler
    #:rotate!
    #:rotate
    #:to-vec3!
@@ -282,8 +284,8 @@
 (define-op inverse ((in quat)) (:out quat)
   (inverse! (id) in))
 
-(define-op rotate! ((out quat) (in quat) (vec v3:vec)
-                    &key (space keyword :local))
+(define-op rotate-euler! ((out quat) (in quat) (vec v3:vec)
+                          &key (space keyword :local))
     (:out quat :inline nil)
   (with-components ((o out) (q in))
     (v3:with-components ((v vec))
@@ -310,9 +312,23 @@
           (%* ow ox oy oz q1w q1x q1y q1z q2w q2x q2y q2z)))))
   out)
 
-(define-op rotate ((in quat) (vec v3:vec) &key (space keyword :local))
+(define-op rotate-euler ((in quat) (vec v3:vec) &key (space keyword :local))
     (:out quat)
-  (rotate! (id) in vec :space space))
+  (rotate-euler! (id) in vec :space space))
+
+(define-op rotate! ((out quat) (in quat) (rot quat)
+                    &key (space keyword :local))
+    (:out quat :inline nil)
+  (ecase space
+    (:local
+      (*! out in rot))
+    (:world
+     (*! out rot in)))
+  (normalize! out out))
+
+(define-op rotate ((in quat) (rot quat) &key (space keyword :local))
+    (:out quat)
+  (rotate! (id) in rot :space space))
 
 (define-op to-vec3! ((out v3:vec) (in quat)) (:out v3:vec)
   (v3:with-components ((v out))

--- a/test/quat.lisp
+++ b/test/quat.lisp
@@ -56,9 +56,9 @@
         (q2 (q:make 10 20 30 40))
         (q3 q:+id+)
         (r (q:make -280 40 60 80))
-        (rot-x (q:rotate q:+id+ (v3:make (/ pi 3) 0 0)))
-        (rot-y (q:rotate q:+id+ (v3:make 0 (/ pi 4) 0)))
-        (rot-xy (q:rotate q:+id+ (v3:make (/ pi 3) (/ pi 4) 0)))
+        (rot-x (q:rotate-euler q:+id+ (v3:make (/ pi 3) 0 0)))
+        (rot-y (q:rotate-euler q:+id+ (v3:make 0 (/ pi 4) 0)))
+        (rot-xy (q:rotate-euler q:+id+ (v3:make (/ pi 3) (/ pi 4) 0)))
         (o (q:zero)))
     (is q:= (q:*! o q1 q2) r)
     (is q:= o r)
@@ -128,7 +128,7 @@
   (is q:= o r)
   (is q:= (q:inverse q) r))
 
-(define-test q/rotate
+(define-test q/rotate-euler
   (let ((oqx (q:id))
         (oqy (q:id))
         (oqz (q:id))
@@ -138,15 +138,15 @@
         (vx (v3:make (/ pi 3) 0 0))
         (vy (v3:make 0 (/ pi 3) 0))
         (vz (v3:make 0 0 (/ pi 3))))
-    (true (q:~ (q:rotate! oqx q:+id+ vx) rqx))
-    (true (q:~ (q:rotate! oqy q:+id+ vy) rqy))
-    (true (q:~ (q:rotate! oqz q:+id+ vz) rqz))
+    (true (q:~ (q:rotate-euler! oqx q:+id+ vx) rqx))
+    (true (q:~ (q:rotate-euler! oqy q:+id+ vy) rqy))
+    (true (q:~ (q:rotate-euler! oqz q:+id+ vz) rqz))
     (true (q:~ oqx rqx))
     (true (q:~ oqy rqy))
     (true (q:~ oqz rqz))
-    (true (q:~ (q:rotate q:+id+ vx) rqx))
-    (true (q:~ (q:rotate q:+id+ vy) rqy))
-    (true (q:~ (q:rotate q:+id+ vz) rqz))))
+    (true (q:~ (q:rotate-euler q:+id+ vx) rqx))
+    (true (q:~ (q:rotate-euler q:+id+ vy) rqy))
+    (true (q:~ (q:rotate-euler q:+id+ vz) rqz))))
 
 (define-test q/vec3-convert
   (let* ((q (q:make 0.3628688 0.9540863 0.017128706 0.32979298))
@@ -177,7 +177,7 @@
     (is q:= (q:from-vec4 v) r)))
 
 (define-test q/mat4-convert
-  (let ((q (q:rotate q:+id+ (v3:make (/ pi 3) 0 0)))
+  (let ((q (q:rotate-euler q:+id+ (v3:make (/ pi 3) 0 0)))
         (qo (q:zero))
         (r (m4:make 1 0 0 0 0 0.5 -0.86602545 0 0 0.86602545 0.5 0 0 0 0 1))
         (mo (m4:id)))


### PR DESCRIPTION
I moved the ROTATE interface to ROTATE-EULER and instead made ROTATE take a quaternion.
I also fixed the tests.