### PR TITLE
Psilord/feature/slerp dot fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ of writing, this currently includes: ABCL, SBCL, CCL, ECL, and Clasp.
 (ql:quickload :origin)
 ```
 
+## Contributors
+
+* [Peter Keller](https://github.com/psilord) - Special thanks for contributions
+  and correctness checking.
+
 ## License
 
 Copyright © 2014-2018 [Michael Fiano](mailto:mail@michaelfiano.com).

--- a/origin.asd
+++ b/origin.asd
@@ -1,5 +1,5 @@
 (asdf:defsystem #:origin
-  :description ""
+  :description "A native Lisp graphics math library with an emphasis on performance and correctness."
   :author "Michael Fiano <mail@michaelfiano.com>"
   :maintainer "Michael Fiano <mail@michaelfiano.com>"
   :license "MIT"

--- a/src/quat.lisp
+++ b/src/quat.lisp
@@ -502,7 +502,7 @@
                  ox (au:lerp factor q1x q2x)
                  oy (au:lerp factor q1y q2y)
                  oz (au:lerp factor q1z q2z))
-          (let* ((angle (acos (au:clamp dot 0 1)))
+          (let* ((angle (acos dot))
                  (sin-angle (sin angle))
                  (scale1 (/ (sin (cl:* angle (cl:- 1 factor))) sin-angle))
                  (scale2 (/ (sin (cl:* factor angle)) sin-angle)))


### PR DESCRIPTION
If you look carefully at the code, the clamp is unnecessary. 